### PR TITLE
feature : 그리 모아보기 창에 greeId 별로 리포트 페이지 연동

### DIFF
--- a/lib/screen/gree/addFavorite.dart
+++ b/lib/screen/gree/addFavorite.dart
@@ -6,6 +6,7 @@ import '../rigging/getImage.dart';
 import '../../screen/root.dart';
 import '../../provider/pageNavi.dart';
 import 'package:provider/provider.dart';
+import '../../service/user_service.dart';
 
 class FavoriteItemCard extends StatefulWidget {
   final Gree gree;
@@ -62,11 +63,25 @@ class _FavoriteItemCardState extends State<FavoriteItemCard> {
           ),
           Align(
             alignment: Alignment.bottomRight,
-            child: ElevatedButton(
-              child: Text('대화 시작'),
-              onPressed: () {
-                pageNavi.changePage('ChatPage', data: PageData(greeId: widget.gree.id));
-              },
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                EleButton_greedot(
+                  isSmall: true,
+                  buttonText: "대화 시작",
+                  fontSize: 11,
+                  padding: EdgeInsets.symmetric(horizontal: 2),
+                  additionalFunc: () => pageNavi.changePage('ChatPage', data: PageData(greeId: widget.gree.id)),
+                ),
+                SizedBox(height: 4), // 버튼 사이의 간격을 조정
+                EleButton_greedot(
+                  isSmall: true,
+                  buttonText: "리포트 보기",
+                  fontSize: 11,
+                  padding: EdgeInsets.symmetric(horizontal: 2),
+                  additionalFunc: () => pageNavi.changePage('ReportPage', data: PageData(greeId: widget.gree.id)),
+                ),
+              ],
             ),
           ),
           Positioned(

--- a/lib/screen/rigging/riggingRoot.dart
+++ b/lib/screen/rigging/riggingRoot.dart
@@ -111,14 +111,10 @@ class _RiggingRootState extends State<RiggingRoot> {
                     mainAxisSize: MainAxisSize.min,
                     children: <Widget>[
                       const SizedBox(height: 35),
-                      Big_EleButton_greedot(
+                      EleButton_greedot(
+                        width: 170, height: 50,
                         additionalFunc: () => pageNavi.changePage('FavoriteListPage'),
                         buttonText: "AI 친구들 모아보기",
-                      ),
-                      const SizedBox(height: 15),
-                      Big_EleButton_greedot(
-                        additionalFunc: () => pageNavi.changePage('SkeletonCanvas'),
-                        buttonText: "우리아이 대화 보기",
                       ),
                     ],
                   ),
@@ -131,14 +127,10 @@ class _RiggingRootState extends State<RiggingRoot> {
                     mainAxisSize: MainAxisSize.min,
                     children: <Widget>[
                       const SizedBox(height: 35),
-                      Big_EleButton_greedot(
+                      EleButton_greedot(
+                        width: 170, height: 50,
                         additionalFunc: () => pageNavi.changePage('newgree'),
                         buttonText: "그리 새로 만들기",
-                      ),
-                      const SizedBox(height: 15),
-                      Big_EleButton_greedot(
-                        additionalFunc: () => pageNavi.changePage('SkeletonCanvas'),
-                        buttonText: "같이 게임하기",
                       ),
                     ],
                   ),

--- a/lib/service/gree_service.dart
+++ b/lib/service/gree_service.dart
@@ -216,6 +216,36 @@ class ApiServiceGree {
       print('Reason: ${responseString.body}');
     }
   }
+
+  static Future<List<String>> fetchSentences(int greeId) async {
+    final url = Uri.parse(
+        '$baseUrl/api/v1/log/sentence/$greeId'); // 실제 URL로 변경 필요
+    final response = await http.get(url);
+    if (response.statusCode == 200) {
+      final data = json.decode(utf8.decode(response.bodyBytes));
+      List<String> sentences = List<String>.from(data['sentences']);
+      return sentences;
+    } else {
+      // 오류 처리
+      throw Exception('Failed to load sentences');
+    }
+  }
+
+  static Future<Map<String, dynamic>> makeEmotionReport(List<String> sentences, int greeId) async {
+    final url = Uri.parse(
+        '$baseUrl/api/v1/ai/make-emotion-report/$greeId');
+    final response = await http.post(
+      url,
+      headers: {'Content-Type': 'application/json'},
+      body: json.encode({'sentences': sentences}),
+    );
+    if (response.statusCode == 200) {
+      return json.decode(utf8.decode(response.bodyBytes));
+    } else {
+      // 오류 처리
+      throw Exception('Failed to make emotion report');
+    }
+  }
 }
 
 


### PR DESCRIPTION
 ## Work summary

     그리 캐릭터가 있는 card에 '대화 하기' 창과 '리포트 보기' 창을 연동하였습니다. 

 ## key change
 
greeId를 이용하여 각 그리와 대화한 내용을 바탕으로 작성된 감정 리포트를 확인할 수 있도록 했습니다.
리포트 페이지를 위한 API는 gree_service.dart에 추가했습니다.
 
 ## How to use

pull 받고 그대로 이용하시면 됩니다.

 ## issue num(optional)

     이슈 링크 참조